### PR TITLE
feat(0002): Availability consistency + sort prenotazioni newest first #2

### DIFF
--- a/.github/workflows/firebase-hosting-pr.yml
+++ b/.github/workflows/firebase-hosting-pr.yml
@@ -1,0 +1,63 @@
+name: Firebase Hosting PR Preview
+
+on:
+  pull_request:
+    branches:
+      - main
+      - develop
+    types: [opened, synchronize, reopened, closed]
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
+jobs:
+  preview:
+    if: github.event.action != 'closed'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Deploy preview channel
+        run: |
+          npx -y firebase-tools@latest hosting:channel:deploy pr-${{ github.event.pull_request.number }} \
+            --project villa-serenita-san-teodoro \
+            --token "$FIREBASE_TOKEN" \
+            --expires 7d \
+            --json > /tmp/channel-output.json
+
+          PREVIEW_URL=$(python3 -c "import json; d=json.load(open('/tmp/channel-output.json')); print(next(iter(d.get('result', {}).get('channels', {}).values()), {}).get('url', ''))")
+          if [ -z "$PREVIEW_URL" ]; then
+            PREVIEW_URL="Preview deployed. Check Firebase Hosting channels in console."
+          fi
+          echo "PREVIEW_URL=$PREVIEW_URL" >> "$GITHUB_ENV"
+        env:
+          FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}
+
+      - name: Comment preview URL
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const url = process.env.PREVIEW_URL;
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: `🔥 **Firebase Preview Deployed!**\n\n📱 Preview URL: ${url}\n\n_This preview will expire in 7 days._`
+            });
+
+  cleanup:
+    if: github.event.action == 'closed'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Delete preview channel
+        run: |
+          npx -y firebase-tools@latest hosting:channel:delete pr-${{ github.event.pull_request.number }} \
+            --project villa-serenita-san-teodoro \
+            --token "$FIREBASE_TOKEN" \
+            --force || true
+        env:
+          FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}

--- a/villa/firestore.rules
+++ b/villa/firestore.rules
@@ -1,0 +1,36 @@
+rules_version='2'
+
+service cloud.firestore {
+  match /databases/{database}/documents {
+    match /reservations/{document=**} {
+      allow create: if true;
+      allow read, update, delete: if request.auth != null;
+    }
+
+    match /calendars/{document=**} {
+      allow read, write: if request.auth != null;
+    }
+
+    match /availability/{document=**} {
+      allow read: if true;
+      allow write: if request.auth != null;
+    }
+    
+    // Public collections - anyone can read, only admins can write
+    match /amenities/{document=**} {
+      allow read: if true;
+      allow write: if request.auth != null && request.auth.token.admin == true;
+    }
+    
+    // Pricing information - public read only
+    match /pricing/{document=**} {
+      allow read: if true;
+      allow write: if request.auth != null && request.auth.token.admin == true;
+    }
+    
+    // Deny everything else by default
+    match /{document=**} {
+      allow read, write: if false;
+    }
+  }
+}

--- a/villa/js/admin.js
+++ b/villa/js/admin.js
@@ -1,0 +1,306 @@
+/**
+ * admin.js - Admin dashboard logic
+ * VillaST - San Teodoro, Sardegna
+ */
+
+import { db, auth } from './firebase-config.js';
+import { loadBookedDates, initAdminCalendar, formatDateISO, saveAvailability } from './calendar.js';
+import {
+  signInWithEmailAndPassword,
+  signOut,
+  onAuthStateChanged
+} from "https://www.gstatic.com/firebasejs/10.12.0/firebase-auth.js";
+import {
+  collection,
+  onSnapshot,
+  getDoc,
+  setDoc,
+  updateDoc,
+  deleteDoc,
+  doc,
+  query,
+  orderBy
+} from "https://www.gstatic.com/firebasejs/10.12.0/firebase-firestore.js";
+
+let unsubscribeReservations = null;
+let adminCalendarInstance = null;
+let originalBookedDates = new Set();
+let currentAdminSelectedDates = [];
+
+function getDatesInRange(checkIn, checkOut) {
+  const dates = [];
+  if (!checkIn || !checkOut) return dates;
+  const current = new Date(checkIn + 'T00:00:00');
+  const end = new Date(checkOut + 'T00:00:00');
+  while (current < end) {
+    dates.push(formatDateISO(current));
+    current.setDate(current.getDate() + 1);
+  }
+  return dates;
+}
+
+function showEl(el) { if (el) el.style.display = ''; }
+function hideEl(el) { if (el) el.style.display = 'none'; }
+
+function showAdminMessage(text, type = 'success') {
+  const el = document.getElementById('admin-message');
+  if (!el) return;
+  el.textContent = text;
+  el.className = `admin-msg admin-msg--${type}`;
+  el.style.display = 'block';
+  setTimeout(() => { el.style.display = 'none'; }, 5000);
+}
+
+function showLoginError(msg) {
+  const el = document.getElementById('login-error');
+  if (!el) return;
+  el.textContent = msg;
+  el.style.display = 'block';
+}
+
+function hideLoginError() {
+  const el = document.getElementById('login-error');
+  if (el) el.style.display = 'none';
+}
+
+function formatDateDisplay(isoStr) {
+  if (!isoStr) return '-';
+  const [y, m, d] = isoStr.split('-');
+  return `${d}/${m}/${y}`;
+}
+
+function statusLabel(status) {
+  const labels = { pending: 'In attesa', confirmed: 'Confermata', rejected: 'Rifiutata' };
+  return labels[status] || status;
+}
+
+function escapeHtml(str) {
+  return String(str)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#039;');
+}
+
+function renderReservations(docs, filterStatus = '') {
+  const tbody = document.getElementById('reservations-tbody');
+  if (!tbody) return;
+
+  const filtered = filterStatus ? docs.filter(d => d.data().status === filterStatus) : docs;
+
+  const allData = docs.map(d => d.data());
+  const pendingCount = allData.filter(d => d.status === 'pending').length;
+  const confirmedCount = allData.filter(d => d.status === 'confirmed').length;
+  const pendingChip = document.querySelector('.stat-chip--pending');
+  const confirmedChip = document.querySelector('.stat-chip--confirmed');
+  if (pendingChip) pendingChip.textContent = `${pendingCount} In attesa`;
+  if (confirmedChip) confirmedChip.textContent = `${confirmedCount} Confermate`;
+
+  if (filtered.length === 0) {
+    tbody.innerHTML = `<tr class="empty-row"><td colspan="6">Nessuna prenotazione trovata</td></tr>`;
+    return;
+  }
+
+  tbody.innerHTML = filtered.map(docSnap => {
+    const d = docSnap.data();
+    const id = docSnap.id;
+    const badgeClass = `badge badge--${d.status}`;
+    return `
+      <tr data-id="${id}">
+        <td><strong>${escapeHtml(d.name || '-')}</strong></td>
+        <td><a href="mailto:${escapeHtml(d.email || '')}">${escapeHtml(d.email || '-')}</a><br><small>${escapeHtml(d.phone || '-')}</small></td>
+        <td>${formatDateDisplay(d.checkIn)} - ${formatDateDisplay(d.checkOut)}</td>
+        <td>${d.guests || '-'}</td>
+        <td><span class="${badgeClass}">${statusLabel(d.status)}</span></td>
+        <td class="action-cell">
+          ${d.status !== 'confirmed' ? `<button class="btn-action btn-confirm" data-id="${id}">Conferma</button>` : ''}
+          ${d.status !== 'rejected' ? `<button class="btn-action btn-reject" data-id="${id}">Rifiuta</button>` : ''}
+          <button class="btn-action btn-delete" data-id="${id}">Elimina</button>
+        </td>
+      </tr>`;
+  }).join('');
+
+  tbody.querySelectorAll('.btn-confirm').forEach(btn => {
+    btn.addEventListener('click', () => updateReservationStatus(btn.dataset.id, 'confirmed'));
+  });
+  tbody.querySelectorAll('.btn-reject').forEach(btn => {
+    btn.addEventListener('click', () => updateReservationStatus(btn.dataset.id, 'rejected'));
+  });
+  tbody.querySelectorAll('.btn-delete').forEach(btn => {
+    btn.addEventListener('click', () => deleteReservation(btn.dataset.id));
+  });
+}
+
+async function updateReservationStatus(id, status) {
+  try {
+    const reservationRef = doc(db, 'reservations', id);
+    const reservationSnap = await getDoc(reservationRef);
+
+    if (!reservationSnap.exists()) {
+      showAdminMessage('Prenotazione non trovata.', 'error');
+      return;
+    }
+
+    const reservationData = reservationSnap.data();
+    const checkIn = reservationData.checkIn;
+    const checkOut = reservationData.checkOut;
+    const oldStatus = reservationData.status;
+    const dates = getDatesInRange(checkIn, checkOut);
+
+    if (status === 'confirmed') {
+      const bookedDates = await loadBookedDates(db);
+      const hasConflict = dates.some(d => bookedDates.has(d));
+      if (hasConflict) {
+        const shouldOverride = confirm('Alcune date risultano gia bloccate. Vuoi confermare comunque la prenotazione?');
+        if (!shouldOverride) return;
+      }
+
+      await Promise.all(dates.map(d => setDoc(doc(db, 'availability', d), { type: 'blocked' })));
+    }
+
+    if (status === 'rejected' && oldStatus === 'confirmed') {
+      await Promise.all(dates.map(d => deleteDoc(doc(db, 'availability', d))));
+    }
+
+    await updateDoc(doc(db, 'reservations', id), { status });
+    showAdminMessage(`Prenotazione ${status === 'confirmed' ? 'confermata' : 'rifiutata'}.`, 'success');
+  } catch (err) {
+    console.error('Update error:', err);
+    showAdminMessage('Errore durante aggiornamento.', 'error');
+  }
+}
+
+async function deleteReservation(id) {
+  if (!confirm('Eliminare questa prenotazione?')) return;
+  try {
+    await deleteDoc(doc(db, 'reservations', id));
+    showAdminMessage('Prenotazione eliminata.', 'success');
+  } catch (err) {
+    console.error('Delete error:', err);
+    showAdminMessage('Errore eliminazione.', 'error');
+  }
+}
+
+function startReservationsListener() {
+  const q = query(collection(db, 'reservations'), orderBy('createdAt', 'desc'));
+  const filterSelect = document.getElementById('filter-status');
+  let allDocs = [];
+
+  unsubscribeReservations = onSnapshot(q, (snapshot) => {
+    allDocs = snapshot.docs;
+    renderReservations(allDocs, filterSelect ? filterSelect.value : '');
+  }, (err) => {
+    console.error('Reservations listener error:', err);
+    showAdminMessage('Errore caricamento prenotazioni.', 'error');
+  });
+
+  if (filterSelect) {
+    filterSelect.addEventListener('change', () => renderReservations(allDocs, filterSelect.value));
+  }
+}
+
+function stopReservationsListener() {
+  if (unsubscribeReservations) { unsubscribeReservations(); unsubscribeReservations = null; }
+}
+
+async function initAdminCalendarSection() {
+  const calendarEl = document.getElementById('admin-calendar');
+  if (!calendarEl) return;
+
+  try { originalBookedDates = await loadBookedDates(db); }
+  catch (err) { console.error('Failed to load booked dates:', err); originalBookedDates = new Set(); }
+
+  adminCalendarInstance = initAdminCalendar(calendarEl, originalBookedDates, (selectedDates) => {
+    currentAdminSelectedDates = selectedDates;
+  });
+  currentAdminSelectedDates = Array.from(originalBookedDates).map(d => new Date(d + 'T00:00:00'));
+
+  const saveBtn = document.getElementById('save-availability-btn');
+  if (saveBtn) {
+    saveBtn.addEventListener('click', async () => {
+      saveBtn.disabled = true;
+      saveBtn.textContent = 'Salvataggio...';
+      try {
+        await saveAvailability(db, originalBookedDates, currentAdminSelectedDates);
+        originalBookedDates = new Set(currentAdminSelectedDates.map(formatDateISO));
+        showAdminMessage('Disponibilita aggiornata!', 'success');
+      } catch (err) {
+        console.error('Save availability error:', err);
+        showAdminMessage('Errore salvataggio.', 'error');
+      } finally {
+        saveBtn.disabled = false;
+        saveBtn.textContent = 'Salva Modifiche';
+      }
+    });
+  }
+}
+
+function initPanelSwitching() {
+  const sidebarLinks = document.querySelectorAll('.sidebar-link[data-panel]');
+  const panels = {
+    reservations: document.getElementById('reservations-panel'),
+    calendar: document.getElementById('calendar-panel')
+  };
+
+  sidebarLinks.forEach(link => {
+    link.addEventListener('click', (e) => {
+      e.preventDefault();
+      const panelName = link.dataset.panel;
+      sidebarLinks.forEach(l => l.classList.remove('active'));
+      link.classList.add('active');
+      Object.entries(panels).forEach(([name, el]) => {
+        if (!el) return;
+        el.style.display = name === panelName ? '' : 'none';
+      });
+      if (panelName === 'calendar' && !adminCalendarInstance) initAdminCalendarSection();
+    });
+  });
+}
+
+function showDashboard() {
+  hideEl(document.getElementById('login-screen'));
+  showEl(document.getElementById('dashboard'));
+  startReservationsListener();
+  initPanelSwitching();
+}
+
+function showLogin() {
+  showEl(document.getElementById('login-screen'));
+  hideEl(document.getElementById('dashboard'));
+  stopReservationsListener();
+  if (adminCalendarInstance) { adminCalendarInstance.destroy(); adminCalendarInstance = null; }
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  onAuthStateChanged(auth, (user) => {
+    if (user) showDashboard(); else showLogin();
+  });
+
+  const loginForm = document.getElementById('login-form');
+  if (loginForm) {
+    loginForm.addEventListener('submit', async (e) => {
+      e.preventDefault();
+      hideLoginError();
+      const email = document.getElementById('login-email').value.trim();
+      const password = document.getElementById('login-password').value;
+      const submitBtn = loginForm.querySelector('[type="submit"]');
+      if (!email || !password) { showLoginError('Inserisci email e password.'); return; }
+      if (submitBtn) { submitBtn.disabled = true; submitBtn.textContent = 'Accesso...'; }
+      try {
+        await signInWithEmailAndPassword(auth, email, password);
+      } catch (err) {
+        console.error('Login error:', err);
+        showLoginError('Email o password non corretti.');
+        if (submitBtn) { submitBtn.disabled = false; submitBtn.textContent = 'Accedi'; }
+      }
+    });
+  }
+
+  const signOutBtn = document.getElementById('sign-out-btn');
+  if (signOutBtn) {
+    signOutBtn.addEventListener('click', async () => {
+      try { await signOut(auth); } catch (err) { console.error('Sign out error:', err); }
+    });
+  }
+});


### PR DESCRIPTION
## Summary

Closes tasks from `.github/tasks/0002.md`.

---

### Issue Fix: Availability consistency across all views

**Root cause:** `firestore.rules` required authentication to _read_ the `availability` collection. Guest users (unauthenticated) couldn't load blocked dates, so `loadBookedDates()` failed silently and the booking form calendar never showed blocked dates.

**Changes:**
- `firestore.rules`: Split `availability` rule — `read: if true` (public), `write: if request.auth != null` (admin only). Guests can now see blocked dates.
- `js/admin.js`: Added `getDatesInRange(checkIn, checkOut)` helper for iterating date ranges.
- `js/admin.js`: Rewrote `updateReservationStatus()` to:
  - **On confirm**: fetch fresh availability via `loadBookedDates()`, check for date conflicts, warn admin if conflict exists (with override option), then write all dates in the reservation range to `availability/{YYYY-MM-DD}`.
  - **On reject**: if the old status was `confirmed`, delete all availability docs in the date range, freeing those dates.

### Feature: Sort prenotazioni by newest first

- `js/admin.js` `startReservationsListener()`: Changed `orderBy('checkIn', 'asc')` → `orderBy('createdAt', 'desc')`. Latest submissions appear at top.

---

### Files changed
| File | Change |
|---|---|
| `villa/firestore.rules` | `availability` read is now public |
| `villa/js/admin.js` | imports, helper, rewritten status fn, sort order |

### Known limitation
Rejecting a confirmed reservation removes _all_ availability docs in its date range, including any that were manually blocked by the admin via the calendar panel. There is no ownership tracking on `{ type: 'blocked' }` docs. Admin must re-block manually if needed.

### Post-merge action required
After merging to `develop` or `main`, run:
```
firebase deploy --only firestore:rules
```
to activate the public-read rule for availability in production.