### PR TITLE
fix+feat: date-range endpoint highlight & availability off-by-one (#5, #6)

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -863,9 +863,18 @@ img {
   border: none !important;
   font-family: var(--font-body) !important;
 }
-.flatpickr-day.selected {
+.flatpickr-day.inRange {
+  background: color-mix(in srgb, var(--azure) 28%, transparent) !important;
+  border-color: color-mix(in srgb, var(--azure) 28%, transparent) !important;
+  color: var(--white) !important;
+}
+.flatpickr-day.selected,
+.flatpickr-day.startRange,
+.flatpickr-day.endRange {
   background: var(--terra) !important;
   border-color: var(--terra) !important;
+  color: var(--white) !important;
+  box-shadow: 0 0 0 1px color-mix(in srgb, var(--terra) 35%, var(--white));
 }
 
 /* ------------------------------------------------------------

--- a/index.html
+++ b/index.html
@@ -255,8 +255,8 @@
             <div class="form-group"><label for="guest-email">Email</label><input id="guest-email" type="email" required maxlength="200" placeholder="mario@example.com"></div>
             <div class="form-group"><label for="guest-phone"><span class="it">Telefono</span><span class="en">Phone</span></label><input id="guest-phone" type="tel" required maxlength="20" placeholder="+39 ..."></div>
             <div class="form-group"><label for="guest-count"><span class="it">Ospiti</span><span class="en">Guests</span></label><select id="guest-count" required><option value="1">1</option><option value="2" selected>2</option><option value="3">3</option><option value="4">4</option><option value="5">5</option><option value="6">6</option><option value="7">7</option><option value="8">8</option></select></div>
-            <div class="form-group"><label for="checkin-date">Check-in</label><input id="checkin-date" type="text" placeholder="Data arrivo / Arrival date" readonly required></div>
-            <div class="form-group"><label for="checkout-date">Check-out</label><input id="checkout-date" type="text" placeholder="Data partenza / Departure date" readonly required></div>
+            <div class="form-group"><label for="checkin-date">Check-in / Check-out</label><input id="checkin-date" type="text" placeholder="Seleziona il periodo / Select stay dates" readonly required></div>
+            <input id="checkout-date" type="hidden">
           </div>
           <div id="availability-loading" style="display:none"><span class="spinner"></span> Caricamento disponibilità...</div>
           <button type="submit" class="btn btn--primary btn--full submit-btn"><span class="it">Richiedi Prenotazione</span><span class="en">Request Booking</span></button>

--- a/js/admin.js
+++ b/js/admin.js
@@ -32,7 +32,7 @@ function getDatesInRange(checkIn, checkOut) {
   if (!checkIn || !checkOut) return dates;
   const current = new Date(checkIn + 'T00:00:00');
   const end = new Date(checkOut + 'T00:00:00');
-  while (current < end) {
+  while (current <= end) {
     dates.push(formatDateISO(current));
     current.setDate(current.getDate() + 1);
   }

--- a/js/calendar.js
+++ b/js/calendar.js
@@ -51,41 +51,39 @@ export async function loadBookedDates(db) {
 export function initGuestCalendar(checkInEl, checkOutEl, bookedDates) {
   const blockedArray = Array.from(bookedDates);
 
-  let checkOutInstance = null;
+  const syncRangeValues = (selectedDates) => {
+    if (selectedDates.length >= 1) {
+      checkInEl.value = formatDateISO(selectedDates[0]);
+    } else {
+      checkInEl.value = '';
+    }
 
-  const checkInInstance = flatpickr(checkInEl, {
-    mode: 'single',
+    if (selectedDates.length === 2) {
+      checkOutEl.value = formatDateISO(selectedDates[1]);
+    } else {
+      checkOutEl.value = '';
+    }
+  };
+
+  const rangeInstance = flatpickr(checkInEl, {
+    mode: 'range',
     dateFormat: 'Y-m-d',
-    altInput: true,
-    altFormat: 'd/m/Y',
     minDate: 'today',
     disable: blockedArray,
+    allowInput: false,
     locale: { firstDayOfWeek: 1 },
+    onReady: (selectedDates) => {
+      syncRangeValues(selectedDates);
+    },
     onChange: (selectedDates) => {
-      if (selectedDates.length > 0 && checkOutInstance) {
-        const nextDay = new Date(selectedDates[0]);
-        nextDay.setDate(nextDay.getDate() + 1);
-        checkOutInstance.set('minDate', nextDay);
-        // Clear checkout if it's now before the new minDate
-        const current = checkOutInstance.selectedDates[0];
-        if (current && current <= selectedDates[0]) {
-          checkOutInstance.clear();
-        }
-      }
+      syncRangeValues(selectedDates);
+    },
+    onClose: (selectedDates) => {
+      syncRangeValues(selectedDates);
     }
   });
 
-  checkOutInstance = flatpickr(checkOutEl, {
-    mode: 'single',
-    dateFormat: 'Y-m-d',
-    altInput: true,
-    altFormat: 'd/m/Y',
-    minDate: 'today',
-    disable: blockedArray,
-    locale: { firstDayOfWeek: 1 }
-  });
-
-  return { checkIn: checkInInstance, checkOut: checkOutInstance };
+  return { checkIn: rangeInstance, checkOut: null };
 }
 
 /**

--- a/js/calendar.js
+++ b/js/calendar.js
@@ -126,7 +126,7 @@ export function dateRangeHasConflict(checkIn, checkOut, bookedDates) {
   const start = new Date(checkIn + 'T00:00:00');
   const end = new Date(checkOut + 'T00:00:00');
   const current = new Date(start);
-  while (current < end) {
+  while (current <= end) {
     if (bookedDates.has(formatDateISO(current))) return true;
     current.setDate(current.getDate() + 1);
   }

--- a/js/reservations.js
+++ b/js/reservations.js
@@ -5,7 +5,7 @@
 
 import { db } from './firebase-config.js';
 import { collection, addDoc, serverTimestamp } from "https://www.gstatic.com/firebasejs/10.12.0/firebase-firestore.js";
-import { loadBookedDates, initGuestCalendar, dateRangeHasConflict } from './calendar.js';
+import { loadBookedDates, initGuestCalendar, dateRangeHasConflict, formatDateISO } from './calendar.js';
 
 function sanitizeString(str) { return String(str).trim(); }
 function isValidEmail(email) { return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email); }
@@ -19,6 +19,25 @@ function showMessage(el, html, type) {
 }
 
 function hideMessage(el) { el.style.display = 'none'; el.innerHTML = ''; }
+
+function getSelectedDateValues(checkInEl, checkOutEl) {
+  let checkIn = sanitizeString(checkInEl.value);
+  let checkOut = sanitizeString(checkOutEl.value);
+
+  if (checkIn.includes(' to ')) {
+    const [start, end] = checkIn.split(' to ').map(v => sanitizeString(v));
+    if (start) checkIn = start;
+    if (!checkOut && end) checkOut = end;
+  }
+
+  const fp = checkInEl._flatpickr;
+  if (fp && Array.isArray(fp.selectedDates)) {
+    if (fp.selectedDates[0]) checkIn = formatDateISO(fp.selectedDates[0]);
+    if (fp.selectedDates[1]) checkOut = formatDateISO(fp.selectedDates[1]);
+  }
+
+  return { checkIn, checkOut };
+}
 
 document.addEventListener('DOMContentLoaded', async () => {
   const form = document.getElementById('reservation-form');
@@ -55,8 +74,7 @@ document.addEventListener('DOMContentLoaded', async () => {
     const email = sanitizeString(emailEl.value);
     const phone = sanitizeString(phoneEl.value);
     const guests = parseInt(countEl.value, 10);
-    const checkIn = sanitizeString(checkInEl.value);
-    const checkOut = sanitizeString(checkOutEl.value);
+    const { checkIn, checkOut } = getSelectedDateValues(checkInEl, checkOutEl);
 
     if (!name || name.length < 2) { showMessage(msgEl, '<p>Inserisci nome e cognome.</p>', 'error'); nameEl.focus(); return; }
     if (name.length > 100) { showMessage(msgEl, '<p>Nome troppo lungo (max 100 caratteri).</p>', 'error'); return; }

--- a/villa/js/admin.js
+++ b/villa/js/admin.js
@@ -32,7 +32,7 @@ function getDatesInRange(checkIn, checkOut) {
   if (!checkIn || !checkOut) return dates;
   const current = new Date(checkIn + 'T00:00:00');
   const end = new Date(checkOut + 'T00:00:00');
-  while (current < end) {
+  while (current <= end) {
     dates.push(formatDateISO(current));
     current.setDate(current.getDate() + 1);
   }


### PR DESCRIPTION
## Summary

Resolves two open issues via 6 atomic commits on `develop`.

---

### Bug Fix — Issue #6: Confirming prenotation blocks wrong dates

**Root cause:** `getDatesInRange` used `while (current < end)` (exclusive), so the check-out day was never written to `availability/{YYYY-MM-DD}` in Firestore.

**Changes:**
- `js/admin.js` — loop condition changed to `current <= end` (includes checkout day)
- `villa/js/admin.js` — same fix applied to nested duplicate
- `js/calendar.js` — `dateRangeHasConflict` consistency fix: conflict checker also now includes checkout day, preventing false-pass on back-to-back bookings

**Before:** Confirmed stay April 3–6 → blocked: 03, 04, 05 (missing 06)
**After:** Confirmed stay April 3–6 → blocked: 03, 04, 05, **06** ✓

---

### Enhancement — Issue #5: CalendarView selected date highlight

**Root cause:** Two separate `mode: 'single'` Flatpickr instances don't emit `.startRange`/`.endRange` CSS classes, making it impossible to style endpoints distinctly from the range fill.

**Changes:**
- `js/calendar.js` — `initGuestCalendar` refactored to a single `mode: 'range'` Flatpickr instance; check-out value synced via `onChange` callback; blocked dates logic preserved
- `js/reservations.js` — date extraction updated to read clean ISO strings from the range instance
- `index.html` — check-out input changed to `type="hidden"`; check-in label updated to "Check-in / Check-out"
- `css/style.css` — Flatpickr overrides expanded: endpoints (`startRange`, `endRange`) use distinct accent color; in-range days use a lighter semi-transparent fill

---

## Commits

| Hash | Message |
|---|---|
| `98ebd15` | fix(admin): include check-out date when blocking availability on confirm (refs #6) |
| `a834470` | fix(calendar): include check-out day in conflict detection for availability (refs #6) |
| `d2230fb` | feat(calendar): refactor guest date picker to range mode for endpoint highlight (refs #5) |
| `5191a30` | refactor(reservations): read dates from range picker correctly (refs #5) |
| `0e6d1fe` | feat(ui): update booking form labels for range picker UX (refs #5) |
| `0a2cbb0` | feat(css): distinct endpoint color for selected check-in/out dates (refs #5) |

---

## DevOps Checklist (per devops.agent.md)
- [ ] All changes on `develop` branch (never touched `main`)
- [x] No secrets or credentials in commits
- [x] PR is `develop → main`
- [x] Firebase preview channel deploy will trigger on this PR

Closes #5
Closes #6