### PR TITLE
feat: Calendar UX, Admin panel sync, conflict handling & reservation linking (issues #8–#12)

### DIFF
--- a/.github/tasks/0005.md
+++ b/.github/tasks/0005.md
@@ -1,0 +1,14 @@
+1. Enhancement #8: CalendarView Select dates — auto-close prevention
+When the user selects the end date in the range calendar (guest booking form), the CalendarView closes automatically. It must stay open until the user explicitly clicks outside or changes focus.
+
+2. Bug #9: CalendarView range selection blocked by unavailable dates
+When selecting a date range that spans blocked/unavailable dates, the entire selection becomes grey and unselectable. Instead: the end date selection should fail gracefully, show a help text "Il periodo selezionato contiene date non disponibili." near the calendar, and keep the start date selected so the user can pick a different end date.
+
+3. Bug #10: Admin calendar dates not reloaded on panel switch
+Switching from the Prenotazioni list to the Calendario panel in the Admin Dashboard does not refresh availability dates from the database. The calendar must reload dates from Firestore every time the panel is activated to stay in sync with confirmations and deletions.
+
+4. Enhancement #11: Confirming Prenotazioni conflict — no JS confirm()
+When confirming a Prenotazione whose dates are already blocked, the system currently uses window.confirm() to ask for override. This must be replaced with a non-blocking UI message at the top of the page. Confirmation must be blocked entirely when dates conflict (no override path).
+
+5. Enhancement #12: Link Prenotazione to availability blocked dates
+When inserting availability records upon reservation confirmation, the availability document must store a reservationId field referencing the source reservation. In the Admin Calendar, hovering over a blocked date must show a tooltip with the name of the associated reservation (or "Bloccata manualmente" for manually-blocked dates).

--- a/css/admin.css
+++ b/css/admin.css
@@ -371,7 +371,19 @@ input, select {
   color: var(--success);
 }
 
+.admin-msg--success {
+  background: rgba(52, 211, 153, 0.1);
+  border: 1px solid var(--success);
+  color: var(--success);
+}
+
 .admin-msg.error {
+  background: rgba(248, 113, 113, 0.1);
+  border: 1px solid var(--danger);
+  color: var(--danger);
+}
+
+.admin-msg--error {
   background: rgba(248, 113, 113, 0.1);
   border: 1px solid var(--danger);
   color: var(--danger);

--- a/css/admin.css
+++ b/css/admin.css
@@ -686,6 +686,7 @@ span.flatpickr-weekday {
   font-weight: 500;
 }
 .flatpickr-day {
+  position: relative;
   color: var(--text) !important;
   border-radius: var(--radius) !important;
   border: 1px solid transparent !important;
@@ -765,4 +766,22 @@ span.flatpickr-weekday {
   .action-btns {
     flex-direction: column;
   }
+}
+
+/* Issue #12 - Day tooltip styles */
+.day-tooltip {
+  position: absolute;
+  bottom: calc(100% + 6px);
+  left: 50%;
+  transform: translateX(-50%);
+  background: #1a1a1a;
+  border: 1px solid rgba(255,255,255,0.15);
+  color: #f0f0f0;
+  font-size: 0.72rem;
+  padding: 0.25rem 0.5rem;
+  border-radius: 4px;
+  white-space: nowrap;
+  pointer-events: none;
+  z-index: 9999;
+  font-family: 'Jost', sans-serif;
 }

--- a/css/style.css
+++ b/css/style.css
@@ -1056,3 +1056,10 @@ img {
     grid-template-columns: 1fr;
   }
 }
+
+.calendar-range-error {
+  color: #c0392b;
+  font-size: 0.85rem;
+  margin-top: 0.35rem;
+  margin-bottom: 0;
+}

--- a/index.html
+++ b/index.html
@@ -255,7 +255,10 @@
             <div class="form-group"><label for="guest-email">Email</label><input id="guest-email" type="email" required maxlength="200" placeholder="mario@example.com"></div>
             <div class="form-group"><label for="guest-phone"><span class="it">Telefono</span><span class="en">Phone</span></label><input id="guest-phone" type="tel" required maxlength="20" placeholder="+39 ..."></div>
             <div class="form-group"><label for="guest-count"><span class="it">Ospiti</span><span class="en">Guests</span></label><select id="guest-count" required><option value="1">1</option><option value="2" selected>2</option><option value="3">3</option><option value="4">4</option><option value="5">5</option><option value="6">6</option><option value="7">7</option><option value="8">8</option></select></div>
-            <div class="form-group"><label for="checkin-date">Check-in / Check-out</label><input id="checkin-date" type="text" placeholder="Seleziona il periodo / Select stay dates" readonly required></div>
+            <div class="form-group"><label for="checkin-date">Check-in / Check-out</label><input id="checkin-date" type="text" placeholder="Seleziona il periodo / Select stay dates" readonly required><p id="calendar-range-error" class="calendar-range-error" style="display:none">
+  <span class="it">Il periodo selezionato contiene date non disponibili.</span>
+  <span class="en" style="display:none">The selected period contains unavailable dates.</span>
+</p></div>
             <input id="checkout-date" type="hidden">
           </div>
           <div id="availability-loading" style="display:none"><span class="spinner"></span> Caricamento disponibilità...</div>

--- a/js/admin.js
+++ b/js/admin.js
@@ -26,6 +26,7 @@ let unsubscribeReservations = null;
 let adminCalendarInstance = null;
 let originalBookedDates = new Set();
 let currentAdminSelectedDates = [];
+let saveAvailabilityListenerAttached = false;
 
 function getDatesInRange(checkIn, checkOut) {
   const dates = [];
@@ -217,6 +218,7 @@ function stopReservationsListener() {
 async function initAdminCalendarSection() {
   const calendarEl = document.getElementById('admin-calendar');
   if (!calendarEl) return;
+  currentAdminSelectedDates = [];
 
   try { originalBookedDates = await loadBookedDates(db); }
   catch (err) { console.error('Failed to load booked dates:', err); originalBookedDates = new Set(); }
@@ -227,7 +229,8 @@ async function initAdminCalendarSection() {
   currentAdminSelectedDates = Array.from(originalBookedDates).map(d => new Date(d + 'T00:00:00'));
 
   const saveBtn = document.getElementById('save-availability-btn');
-  if (saveBtn) {
+  if (saveBtn && !saveAvailabilityListenerAttached) {
+    saveAvailabilityListenerAttached = true;
     saveBtn.addEventListener('click', async () => {
       saveBtn.disabled = true;
       saveBtn.textContent = 'Salvataggio...';
@@ -263,7 +266,13 @@ function initPanelSwitching() {
         if (!el) return;
         el.style.display = name === panelName ? '' : 'none';
       });
-      if (panelName === 'calendar' && !adminCalendarInstance) initAdminCalendarSection();
+      if (panelName === 'calendar') {
+        if (adminCalendarInstance) {
+          adminCalendarInstance.destroy();
+          adminCalendarInstance = null;
+        }
+        initAdminCalendarSection();
+      }
     });
   });
 }

--- a/js/admin.js
+++ b/js/admin.js
@@ -153,8 +153,11 @@ async function updateReservationStatus(id, status) {
       const bookedDates = await loadBookedDates(db);
       const hasConflict = dates.some(d => bookedDates.has(d));
       if (hasConflict) {
-        const shouldOverride = confirm('Alcune date risultano gia bloccate. Vuoi confermare comunque la prenotazione?');
-        if (!shouldOverride) return;
+        showAdminMessage(
+          'Alcune date risultano già bloccate. Impossibile confermare questa prenotazione.',
+          'error'
+        );
+        return;
       }
       await Promise.all(dates.map(d => setDoc(doc(db, 'availability', d), { type: 'blocked' })));
     }

--- a/js/admin.js
+++ b/js/admin.js
@@ -4,7 +4,7 @@
  */
 
 import { db, auth } from './firebase-config.js';
-import { loadBookedDates, initAdminCalendar, formatDateISO, saveAvailability } from './calendar.js';
+import { loadBookedDates, loadBookedDatesWithMeta, initAdminCalendar, formatDateISO, saveAvailability } from './calendar.js';
 import {
   signInWithEmailAndPassword,
   signOut,
@@ -27,6 +27,7 @@ let adminCalendarInstance = null;
 let originalBookedDates = new Set();
 let currentAdminSelectedDates = [];
 let saveAvailabilityListenerAttached = false;
+let bookedDatesMeta = new Map();
 
 function getDatesInRange(checkIn, checkOut) {
   const dates = [];
@@ -159,7 +160,7 @@ async function updateReservationStatus(id, status) {
         );
         return;
       }
-      await Promise.all(dates.map(d => setDoc(doc(db, 'availability', d), { type: 'blocked' })));
+      await Promise.all(dates.map(d => setDoc(doc(db, 'availability', d), { type: 'blocked', reservationId: id })));
     }
 
     if (status === 'rejected' && oldStatus === 'confirmed') {
@@ -218,17 +219,77 @@ function stopReservationsListener() {
   if (unsubscribeReservations) { unsubscribeReservations(); unsubscribeReservations = null; }
 }
 
+function attachDayTooltips(calendarEl) {
+  calendarEl.querySelectorAll('.flatpickr-day:not(.prevMonthDay):not(.nextMonthDay)').forEach(dayEl => {
+    dayEl.addEventListener('mouseenter', onDayMouseenter);
+    dayEl.addEventListener('mouseleave', onDayMouseleave);
+  });
+}
+
+function onDayMouseleave(e) {
+  const existing = e.currentTarget.querySelector('.day-tooltip');
+  if (existing) existing.remove();
+}
+
+async function onDayMouseenter(e) {
+  const dayEl = e.currentTarget;
+  if (dayEl.classList.contains('flatpickr-disabled')) return;
+
+  const ariaLabel = dayEl.getAttribute('aria-label');
+  if (!ariaLabel) return;
+
+  const parsed = new Date(ariaLabel);
+  if (isNaN(parsed.getTime())) return;
+  const dateStr = formatDateISO(parsed);
+
+  const meta = bookedDatesMeta.get(dateStr);
+  if (!meta) return;
+
+  let tooltip = document.createElement('div');
+  tooltip.className = 'day-tooltip';
+  tooltip.textContent = '...';
+  dayEl.style.position = 'relative';
+  dayEl.appendChild(tooltip);
+
+  if (meta.reservationId) {
+    try {
+      const resSnap = await getDoc(doc(db, 'reservations', meta.reservationId));
+      if (!dayEl.querySelector('.day-tooltip')) return;
+      if (resSnap.exists()) {
+        tooltip.textContent = resSnap.data().name || 'Prenotazione';
+      } else {
+        tooltip.textContent = 'Prenotazione non trovata';
+      }
+    } catch {
+      if (dayEl.querySelector('.day-tooltip')) tooltip.textContent = 'Errore';
+    }
+  } else {
+    tooltip.textContent = 'Bloccata manualmente';
+  }
+}
+
 async function initAdminCalendarSection() {
   const calendarEl = document.getElementById('admin-calendar');
   if (!calendarEl) return;
   currentAdminSelectedDates = [];
 
-  try { originalBookedDates = await loadBookedDates(db); }
-  catch (err) { console.error('Failed to load booked dates:', err); originalBookedDates = new Set(); }
+  try {
+    bookedDatesMeta = await loadBookedDatesWithMeta(db);
+    originalBookedDates = new Set(bookedDatesMeta.keys());
+  }
+  catch (err) {
+    console.error('Failed to load booked dates:', err);
+    bookedDatesMeta = new Map();
+    originalBookedDates = new Set();
+  }
 
   adminCalendarInstance = initAdminCalendar(calendarEl, originalBookedDates, (selectedDates) => {
     currentAdminSelectedDates = selectedDates;
+  }, {
+    onMonthChange: () => { attachDayTooltips(calendarEl); },
+    onYearChange: () => { attachDayTooltips(calendarEl); }
   });
+  attachDayTooltips(calendarEl);
   currentAdminSelectedDates = Array.from(originalBookedDates).map(d => new Date(d + 'T00:00:00'));
 
   const saveBtn = document.getElementById('save-availability-btn');

--- a/js/calendar.js
+++ b/js/calendar.js
@@ -50,6 +50,7 @@ export async function loadBookedDates(db) {
  */
 export function initGuestCalendar(checkInEl, checkOutEl, bookedDates) {
   const blockedArray = Array.from(bookedDates);
+  const errorEl = document.getElementById('calendar-range-error');
 
   const syncRangeValues = (selectedDates) => {
     if (selectedDates.length >= 1) {
@@ -57,7 +58,6 @@ export function initGuestCalendar(checkInEl, checkOutEl, bookedDates) {
     } else {
       checkInEl.value = '';
     }
-
     if (selectedDates.length === 2) {
       checkOutEl.value = formatDateISO(selectedDates[1]);
     } else {
@@ -65,17 +65,41 @@ export function initGuestCalendar(checkInEl, checkOutEl, bookedDates) {
     }
   };
 
-  const rangeInstance = flatpickr(checkInEl, {
+  const rangeHasBlockedDate = (start, end) => {
+    const current = new Date(start.getTime());
+    const endTime = end.getTime();
+    while (current.getTime() <= endTime) {
+      if (bookedDates.has(formatDateISO(current))) return true;
+      current.setDate(current.getDate() + 1);
+    }
+    return false;
+  };
+
+  let isResolvingConflict = false;
+
+  let rangeInstance;
+  rangeInstance = flatpickr(checkInEl, {
     mode: 'range',
     dateFormat: 'Y-m-d',
     minDate: 'today',
     disable: blockedArray,
     allowInput: false,
+    closeOnSelect: false,
     locale: { firstDayOfWeek: 1 },
-    onReady: (selectedDates) => {
-      syncRangeValues(selectedDates);
-    },
+    onReady: (selectedDates) => { syncRangeValues(selectedDates); },
     onChange: (selectedDates) => {
+      if (isResolvingConflict) return;
+      if (selectedDates.length === 2) {
+        if (rangeHasBlockedDate(selectedDates[0], selectedDates[1])) {
+          isResolvingConflict = true;
+          rangeInstance.setDate([selectedDates[0]], false);
+          isResolvingConflict = false;
+          if (errorEl) errorEl.style.display = '';
+          syncRangeValues([selectedDates[0]]);
+          return;
+        }
+      }
+      if (errorEl) errorEl.style.display = 'none';
       syncRangeValues(selectedDates);
     },
     onClose: (selectedDates) => {

--- a/js/calendar.js
+++ b/js/calendar.js
@@ -41,6 +41,18 @@ export async function loadBookedDates(db) {
   return blocked;
 }
 
+export async function loadBookedDatesWithMeta(db) {
+  const snap = await getDocs(collection(db, 'availability'));
+  const meta = new Map();
+  snap.forEach(docSnap => {
+    const data = docSnap.data();
+    if (data.type === 'blocked') {
+      meta.set(docSnap.id, { type: 'blocked', reservationId: data.reservationId || null });
+    }
+  });
+  return meta;
+}
+
 /**
  * Initialize the guest-facing check-in/check-out date pickers
  * Uses Flatpickr (loaded globally on page via CDN)
@@ -115,9 +127,10 @@ export function initGuestCalendar(checkInEl, checkOutEl, bookedDates) {
  * @param {HTMLElement} el — container element for inline calendar
  * @param {Set<string>} bookedDates — initial blocked dates
  * @param {function(Date[]): void} onChange — called when selection changes
+ * @param {object} extraOptions - additional Flatpickr options
  * @returns {object} Flatpickr instance
  */
-export function initAdminCalendar(el, bookedDates, onChange) {
+export function initAdminCalendar(el, bookedDates, onChange, extraOptions = {}) {
   const preselected = Array.from(bookedDates);
 
   return flatpickr(el, {
@@ -130,7 +143,8 @@ export function initAdminCalendar(el, bookedDates, onChange) {
       if (typeof onChange === 'function') {
         onChange(selectedDates);
       }
-    }
+    },
+    ...extraOptions
   });
 }
 


### PR DESCRIPTION
# VillaST — Issues #8–#12

Closes #8, #9, #10, #11, #12

## Summary

This PR resolves 5 open issues across the guest calendar, admin confirmation flow, and the availability data schema. All changes follow the VillaST coding standards and branch strategy defined in `.github/agents/`.

---

## Changes by Issue

### 🐛 Fix #8 — CalendarView no longer auto-closes on end-date selection
**File:** `villa/js/calendar.js`

Added `closeOnSelect: false` to the `initGuestCalendar` Flatpickr config. The calendar now stays open after the user selects the end date of a range, requiring an explicit click outside to close.

---

### 🐛 Fix #9 — Blocked date inside range: graceful rejection with inline error
**Files:** `villa/js/calendar.js`, `villa/index.html`, `villa/css/style.css`

When a guest attempts to select a date range that spans a blocked date:
- The end date selection is rejected (start date is kept)
- An inline help text appears below the calendar: *"Il periodo selezionato contiene date non disponibili."*
- The error text is hidden automatically when a valid (conflict-free) range is selected
- A re-entrancy guard (`isResolvingConflict`) prevents recursive `onChange` calls from the programmatic `setDate` clear

---

### 🐛 Fix #10 — Admin calendar always reloads dates from Firestore on tab switch
**File:** `villa/js/admin.js`

Removed the `!adminCalendarInstance` guard in `initPanelSwitching`. The calendar is now destroyed and fully re-initialised with fresh Firestore data every time the Calendario panel is activated. A `saveAvailabilityListenerAttached` flag prevents duplicate click listeners accumulating on the save button across multiple re-inits.

---

### ✨ Enhancement #11 — Date conflict blocks confirmation; no more `window.confirm()`
**Files:** `villa/js/admin.js`, `villa/css/admin.css`

When confirming a Prenotazione with already-blocked dates, the system now:
- Shows a persistent error banner at the top of the admin page via `showAdminMessage()`
- Returns immediately — no override path (confirmation is blocked, not warned)
- Removes the `window.confirm()` call entirely

Also fixed a latent CSS bug: `showAdminMessage` sets BEM modifier classes (`admin-msg--success`, `admin-msg--error`) but the stylesheet only had chained selectors (`.admin-msg.success`). Both variant forms are now defined in `admin.css`.

---

### ✨ Enhancement #12 — Reservation IDs stored in availability docs; admin calendar hover tooltip
**Files:** `villa/js/admin.js`, `villa/js/calendar.js`, `villa/css/admin.css`

**Schema change:** Availability documents now store a `reservationId` field when created by a reservation confirmation:
```
availability/{YYYY-MM-DD}: { type: "blocked", reservationId: "<reservationDocId>" }
```
Manually-blocked dates retain `{ type: "blocked" }` with no `reservationId` (backward-compatible).

**New export `loadBookedDatesWithMeta`** in `calendar.js`: returns a `Map<YYYY-MM-DD, {type, reservationId|null}>` for use in the admin calendar.

**Hover tooltip on admin calendar days:** Hovering a blocked date in the inline admin calendar now shows a tooltip:
- With `reservationId`: fetches the Prenotazione from Firestore and displays the guest name
- Without `reservationId` (manually blocked): shows *"Bloccata manualmente"*
- Loading state shown as `...` while the async Firestore fetch resolves
- Tooltip is removed on `mouseleave` (stale async results are discarded)
- `attachDayTooltips()` is re-called on Flatpickr month/year navigation to re-attach listeners to newly-rendered day cells

---

## Commits

| SHA | Message |
|---|---|
| `3fb66db` | chore: add task manifest 0005 for issues #8-#12 |
| `48df927` | fix(calendar): prevent auto-close on range select (#8); show inline error for blocked date ranges (#9) |
| `b79b61e` | fix(admin): reload availability dates from DB on every calendar tab switch (#10) |
| `c2e40ff` | fix(admin): replace window.confirm() with UI banner for date conflict on confirm (#11) |
| `e48872c` | feat(admin): link reservations to availability docs; add hover tooltip on calendar (#12); store reservationId on confirm |

---

## Testing Checklist

- [ ] Guest calendar stays open after selecting end date
- [ ] Selecting a range over a blocked date shows inline error and keeps start date
- [ ] Switching to Calendario tab always shows fresh data from Firestore
- [ ] Confirming a Prenotazione with conflicting dates shows error banner (no override)
- [ ] Confirmed reservations write `{ type: "blocked", reservationId }` to Firestore
- [ ] Hovering a confirmed-reservation date in admin calendar shows guest name
- [ ] Hovering a manually-blocked date shows "Bloccata manualmente"
- [ ] Old availability docs (no reservationId) degrade gracefully in tooltip